### PR TITLE
Add bootstrap frontend with login & registration

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <style>
+        body {font-family:'Poppins', sans-serif; background:#f2f4f6;}
+        header {background:#0d6efd; color:white; padding:1rem;}
+        .cards {display:flex; flex-wrap:wrap; gap:1rem;}
+    </style>
+</head>
+<body>
+<header>
+    <h1>Arivu Dashboard</h1>
+</header>
+<div class="container my-4">
+    <div class="cards">
+        <div class="card flex-fill">
+            <div class="card-body">
+                <h5 class="card-title">Inventory Item</h5>
+                <pre id="inv"></pre>
+            </div>
+        </div>
+        <div class="card flex-fill">
+            <div class="card-body">
+                <h5 class="card-title">Admin Dashboard</h5>
+                <pre id="dash"></pre>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+async function load() {
+    const token = localStorage.getItem('token');
+    const inv = await fetch('/inventory/1');
+    if (inv.ok) {
+        document.getElementById('inv').textContent = JSON.stringify(await inv.json(), null, 2);
+    }
+    const dash = await fetch('/dashboard/admin');
+    if (dash.ok) {
+        document.getElementById('dash').textContent = JSON.stringify(await dash.json(), null, 2);
+    }
+}
+load();
+</script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,52 +3,44 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Arivu SCM</title>
+    <title>Arivu SCM Login</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <style>
-        body { font-family: Arial, sans-serif; margin:0; padding:0; }
-        header { background:#0c4a6e; color:white; padding:1rem; text-align:center; }
-        .content { padding:1rem; }
-        nav { display:flex; justify-content:space-around; background:#e2e8f0; padding:0.5rem; }
-        nav a { color:#0c4a6e; text-decoration:none; font-weight:bold; }
-        .card { border:1px solid #ccc; border-radius:8px; padding:1rem; margin-top:1rem; }
-        @media (min-width:600px) {
-            .cards { display:flex; gap:1rem; }
-        }
+        body {font-family:'Poppins', sans-serif; background:#f2f4f6;}
+        .login-box {max-width:400px; margin:auto; margin-top:10vh; padding:2rem; background:white; border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.1);}
     </style>
 </head>
 <body>
-    <header>
-        <h1>Arivu Supply Chain</h1>
-    </header>
-    <nav>
-        <a href="#inventory">Inventory</a>
-        <a href="#orders">Orders</a>
-        <a href="#customers">Customers</a>
-    </nav>
-    <div class="content">
-        <div class="cards">
-            <div class="card" id="inventory">
-                <h2>Inventory Item</h2>
-                <pre id="inv"></pre>
-            </div>
-            <div class="card" id="dashboard">
-                <h2>Admin Dashboard</h2>
-                <pre id="dash"></pre>
-            </div>
+<div class="login-box">
+    <h2 class="mb-4 text-center">Arivu SCM Login</h2>
+    <form id="loginForm">
+        <div class="mb-3">
+            <label for="username" class="form-label">Username</label>
+            <input type="text" class="form-control" id="username" required>
         </div>
-    </div>
-    <script>
-        async function load() {
-            const inv = await fetch('/inventory/1');
-            if (inv.ok) {
-                document.getElementById('inv').textContent = JSON.stringify(await inv.json(), null, 2);
-            }
-            const dash = await fetch('/dashboard/admin');
-            if (dash.ok) {
-                document.getElementById('dash').textContent = JSON.stringify(await dash.json(), null, 2);
-            }
-        }
-        load();
-    </script>
+        <div class="mb-3">
+            <label for="password" class="form-label">Password</label>
+            <input type="password" class="form-control" id="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary w-100">Login</button>
+        <div class="text-center mt-3">
+            <a href="/register.html">Register</a>
+        </div>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+document.getElementById('loginForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const resp = await fetch('/auth/login?username=' + document.getElementById('username').value + '&password=' + document.getElementById('password').value, {method:'POST'});
+    if (resp.ok) {
+        localStorage.setItem('token', (await resp.json()).token);
+        window.location.href = '/dashboard.html';
+    } else {
+        alert('Invalid credentials');
+    }
+});
+</script>
 </body>
 </html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Register</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <style>
+        body {font-family:'Poppins', sans-serif; background:#f2f4f6;}
+        .register-box {max-width:400px; margin:auto; margin-top:10vh; padding:2rem; background:white; border-radius:8px; box-shadow:0 0 10px rgba(0,0,0,0.1);}
+    </style>
+</head>
+<body>
+<div class="register-box">
+    <h2 class="mb-4 text-center">Create Account</h2>
+    <form id="registerForm">
+        <div class="mb-3">
+            <label class="form-label" for="username">Username</label>
+            <input class="form-control" id="username" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="password">Password</label>
+            <input type="password" class="form-control" id="password" required>
+        </div>
+        <button class="btn btn-primary w-100" type="submit">Register</button>
+    </form>
+</div>
+<script>
+document.getElementById('registerForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const resp = await fetch('/auth/register?username=' + document.getElementById('username').value + '&password=' + document.getElementById('password').value, {method:'POST'});
+    if (resp.ok) {
+        alert('Registration successful');
+        window.location.href = '/';
+    } else {
+        const data = await resp.json();
+        alert('Error: ' + data.detail);
+    }
+});
+</script>
+</body>
+</html>

--- a/supply_chain_system/auth/routes.py
+++ b/supply_chain_system/auth/routes.py
@@ -1,19 +1,29 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+from typing import Dict
 
 router = APIRouter()
 
 class Token(BaseModel):
     token: str
 
-fake_user = {
-    "username": "admin",
-    "password": "password",
-    "token": "secret-token",
+users_db: Dict[str, Dict[str, str]] = {
+    "admin": {"password": "password"}
 }
+
+def create_token(username: str) -> str:
+    return f"token-{username}"
+
+@router.post("/register")
+async def register(username: str, password: str):
+    if username in users_db:
+        raise HTTPException(status_code=400, detail="User already exists")
+    users_db[username] = {"password": password}
+    return {"message": "registered"}
 
 @router.post("/login")
 async def login(username: str, password: str):
-    if username == fake_user["username"] and password == fake_user["password"]:
-        return Token(token=fake_user["token"])
+    user = users_db.get(username)
+    if user and user["password"] == password:
+        return Token(token=create_token(username))
     raise HTTPException(status_code=401, detail="Invalid credentials")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,10 +5,10 @@ from supply_chain_system.main import app
 
 client = TestClient(app)
 
-def test_root():
+def test_root_serves_html():
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == {"message": "Arivu Supply Chain API"}
+    assert "text/html" in response.headers["content-type"]
 
 
 def test_inventory_add_and_get():
@@ -17,3 +17,11 @@ def test_inventory_add_and_get():
     assert add_resp.status_code == 200
     get_resp = client.get("/inventory/1")
     assert get_resp.json()["name"] == "Flour"
+
+
+def test_register_and_login():
+    reg = client.post("/auth/register", params={"username": "test", "password": "pass"})
+    assert reg.status_code == 200
+    log = client.post("/auth/login", params={"username": "test", "password": "pass"})
+    assert log.status_code == 200
+    assert "token" in log.json()


### PR DESCRIPTION
## Summary
- implement login/registration endpoints with in-memory user DB
- serve frontend files and default login page
- add bootstrap-based login, register and dashboard pages
- adjust tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff4c04da8832ab8157a0ef3e50b4d