### PR TITLE
Add admin inventory CRUD with sample data

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -29,7 +29,7 @@
     </div>
     <div class="offcanvas-body p-0">
         <ul class="list-group list-group-flush">
-            <li class="list-group-item"><a href="#inventory" class="nav-link" data-bs-dismiss="offcanvas">Inventory</a></li>
+            <li class="list-group-item"><a href="/inventory.html" class="nav-link" data-bs-dismiss="offcanvas">Inventory</a></li>
             <li class="list-group-item"><a href="#customers" class="nav-link" data-bs-dismiss="offcanvas">Customers</a></li>
             <li class="list-group-item"><a href="#invoices" class="nav-link" data-bs-dismiss="offcanvas">Invoices</a></li>
         </ul>

--- a/frontend/inventory.html
+++ b/frontend/inventory.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Inventory Management</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<h2 class="mb-3">Inventory Management</h2>
+<table class="table" id="invTable">
+    <thead>
+        <tr><th>ID</th><th>Name</th><th>Qty</th><th>Actions</th></tr>
+    </thead>
+    <tbody></tbody>
+</table>
+<h3>Add / Update Item</h3>
+<form id="itemForm" class="row g-2">
+    <div class="col-auto"><input class="form-control" id="id" placeholder="ID" required></div>
+    <div class="col-auto"><input class="form-control" id="name" placeholder="Name" required></div>
+    <div class="col-auto"><input class="form-control" id="qty" type="number" placeholder="Quantity" required></div>
+    <div class="col-auto"><button class="btn btn-primary" type="submit">Save</button></div>
+</form>
+<script>
+async function load() {
+    const resp = await fetch('/inventory');
+    if(!resp.ok) return;
+    const data = await resp.json();
+    const tbody = document.querySelector('#invTable tbody');
+    tbody.innerHTML = '';
+    data.forEach(i => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${i.id}</td><td>${i.name}</td><td>${i.quantity}</td>`;
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Delete';
+        delBtn.className = 'btn btn-danger btn-sm';
+        delBtn.onclick = async () => {
+            await fetch('/inventory/' + i.id, {method:'DELETE'});
+            load();
+        };
+        const td = document.createElement('td');
+        td.appendChild(delBtn);
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('itemForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const item = {
+        id: parseInt(document.getElementById('id').value),
+        name: document.getElementById('name').value,
+        quantity: parseInt(document.getElementById('qty').value)
+    };
+    const method = await fetch('/inventory/' + item.id, {method:'GET'});
+    if(method.ok){
+        await fetch('/inventory/' + item.id, {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(item)});
+    } else {
+        await fetch('/inventory', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(item)});
+    }
+    document.getElementById('itemForm').reset();
+    load();
+});
+
+load();
+</script>
+</body>
+</html>

--- a/supply_chain_system/inventory/routes.py
+++ b/supply_chain_system/inventory/routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Dict, List
 
@@ -9,9 +9,17 @@ class InventoryItem(BaseModel):
     name: str
     quantity: int
 
-# In-memory store for demo
-inventory: Dict[int, InventoryItem] = {}
-inventory_logs: List[str] = []
+# In-memory store for demo with sample data
+inventory: Dict[int, InventoryItem] = {
+    1: InventoryItem(id=1, name="Rice", quantity=50),
+    2: InventoryItem(id=2, name="Oil", quantity=20),
+    3: InventoryItem(id=3, name="Spices", quantity=30),
+}
+inventory_logs: List[str] = [
+    "Preloaded Rice(1) qty 50",
+    "Preloaded Oil(2) qty 20",
+    "Preloaded Spices(3) qty 30",
+]
 
 @router.get("/")
 async def list_items():
@@ -20,7 +28,10 @@ async def list_items():
 
 @router.get("/{item_id}")
 async def get_item(item_id: int):
-    return inventory.get(item_id, {"error": "Item not found"})
+    item = inventory.get(item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
 
 @router.post("/")
 async def add_item(item: InventoryItem):
@@ -29,11 +40,27 @@ async def add_item(item: InventoryItem):
     return item
 
 
-@router.post("/update")
-async def update_item(item: InventoryItem):
+@router.put("/{item_id}")
+async def update_item(item_id: int, item: InventoryItem):
+    if item_id not in inventory:
+        raise HTTPException(status_code=404, detail="Item not found")
+    inventory[item_id] = item
+    inventory_logs.append(f"Updated {item.name}({item.id}) qty {item.quantity}")
+    return item
+
+@router.post("/update")  # backward compatibility
+async def update_item_post(item: InventoryItem):
     inventory[item.id] = item
     inventory_logs.append(f"Updated {item.name}({item.id}) qty {item.quantity}")
     return item
+
+@router.delete("/{item_id}")
+async def delete_item(item_id: int):
+    item = inventory.pop(item_id, None)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    inventory_logs.append(f"Deleted {item.name}({item.id})")
+    return {"status": "deleted"}
 
 
 @router.get("/logs")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,11 +12,23 @@ def test_root_serves_html():
 
 
 def test_inventory_add_and_get():
-    item = {"id": 1, "name": "Flour", "quantity": 10}
+    item = {"id": 99, "name": "Flour", "quantity": 10}
     add_resp = client.post("/inventory/", json=item)
     assert add_resp.status_code == 200
-    get_resp = client.get("/inventory/1")
+    get_resp = client.get("/inventory/99")
     assert get_resp.json()["name"] == "Flour"
+
+
+def test_inventory_crud():
+    initial = client.get("/inventory")
+    assert len(initial.json()) >= 3
+    item = {"id": 100, "name": "Sugar", "quantity": 5}
+    assert client.post("/inventory", json=item).status_code == 200
+    updated = {"id": 100, "name": "Sugar", "quantity": 8}
+    assert client.put("/inventory/100", json=updated).status_code == 200
+    assert client.delete("/inventory/100").status_code == 200
+    missing = client.get("/inventory/100")
+    assert missing.status_code == 404
 
 
 def test_register_and_login():


### PR DESCRIPTION
## Summary
- preload inventory with sample data
- support update & delete inventory items
- add an Inventory Management page
- link new page from dashboard
- extend tests for CRUD

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fffcf428c832a985dc0742768edd0