### PR TITLE
Add DB-backed inventory CRUD and view page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-__pycache__/\n*.pyc\n
+__pycache__/
+**/__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -153,3 +153,4 @@ oracle.com
 trilinkftz.com
 . With this foundation in place, Arivu Foods can focus on expanding its market and product offerings, confident that the supply chain system will support and drive that growth.
 \n## Running the API\n\nInstall dependencies and run:\n```\npip install -r requirements.txt\nuvicorn app.main:app --reload\n```\n
+Sample inventory data is automatically loaded into a local SQLite database on startup.\n

--- a/frontend/inventory.html
+++ b/frontend/inventory.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Inventory</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<div class="container py-4">
+    <h2 class="mb-3">Inventory</h2>
+    <table class="table" id="invTable">
+        <thead><tr><th>ID</th><th>Name</th><th>Quantity</th></tr></thead>
+        <tbody></tbody>
+    </table>
+</div>
+<script>
+async function loadInventory() {
+    const resp = await fetch('/inventory');
+    if (resp.ok) {
+        const data = await resp.json();
+        const tbody = document.querySelector('#invTable tbody');
+        tbody.innerHTML = '';
+        data.forEach(i => {
+            const row = document.createElement('tr');
+            row.innerHTML = `<td>${i.id}</td><td>${i.name}</td><td>${i.quantity}</td>`;
+            tbody.appendChild(row);
+        });
+    }
+}
+loadInventory();
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pydantic
 pytest
 httpx
+SQLAlchemy

--- a/supply_chain_system/database/core.py
+++ b/supply_chain_system/database/core.py
@@ -1,2 +1,19 @@
-# Placeholder database connection
-DB = {}
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./scms.db"
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/supply_chain_system/inventory/init_db.py
+++ b/supply_chain_system/inventory/init_db.py
@@ -1,0 +1,18 @@
+from sqlalchemy.orm import Session
+
+from .models import InventoryItem
+from ..database.core import Base, engine, SessionLocal
+
+
+def init_inventory():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db: Session = SessionLocal()
+    if db.query(InventoryItem).count() == 0:
+        samples = [
+            InventoryItem(id=1, name="Flour", quantity=100),
+            InventoryItem(id=2, name="Oil", quantity=50),
+        ]
+        db.add_all(samples)
+        db.commit()
+    db.close()

--- a/supply_chain_system/inventory/models.py
+++ b/supply_chain_system/inventory/models.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String
+from ..database.core import Base
+
+class InventoryItem(Base):
+    __tablename__ = "inventory"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    quantity = Column(Integer, default=0)

--- a/supply_chain_system/inventory/routes.py
+++ b/supply_chain_system/inventory/routes.py
@@ -1,41 +1,59 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from typing import Dict, List
+from sqlalchemy.orm import Session
+from typing import List
+
+from .models import InventoryItem
+from ..database.core import get_db
 
 router = APIRouter()
 
-class InventoryItem(BaseModel):
+class InventoryCreate(BaseModel):
     id: int
     name: str
     quantity: int
 
-# In-memory store for demo
-inventory: Dict[int, InventoryItem] = {}
-inventory_logs: List[str] = []
+class InventoryUpdate(BaseModel):
+    name: str | None = None
+    quantity: int | None = None
 
 @router.get("/")
-async def list_items():
-    return list(inventory.values())
-
+async def list_items(db: Session = Depends(get_db)):
+    return db.query(InventoryItem).all()
 
 @router.get("/{item_id}")
-async def get_item(item_id: int):
-    return inventory.get(item_id, {"error": "Item not found"})
+async def get_item(item_id: int, db: Session = Depends(get_db)):
+    item = db.query(InventoryItem).get(item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
 
 @router.post("/")
-async def add_item(item: InventoryItem):
-    inventory[item.id] = item
-    inventory_logs.append(f"Added {item.name}({item.id}) qty {item.quantity}")
-    return item
+async def add_item(item: InventoryCreate, db: Session = Depends(get_db)):
+    db_item = InventoryItem(id=item.id, name=item.name, quantity=item.quantity)
+    db.add(db_item)
+    db.commit()
+    db.refresh(db_item)
+    return db_item
 
+@router.put("/{item_id}")
+async def update_item(item_id: int, item: InventoryUpdate, db: Session = Depends(get_db)):
+    db_item = db.query(InventoryItem).get(item_id)
+    if not db_item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    if item.name is not None:
+        db_item.name = item.name
+    if item.quantity is not None:
+        db_item.quantity = item.quantity
+    db.commit()
+    db.refresh(db_item)
+    return db_item
 
-@router.post("/update")
-async def update_item(item: InventoryItem):
-    inventory[item.id] = item
-    inventory_logs.append(f"Updated {item.name}({item.id}) qty {item.quantity}")
-    return item
-
-
-@router.get("/logs")
-async def get_logs():
-    return {"logs": inventory_logs}
+@router.delete("/{item_id}")
+async def delete_item(item_id: int, db: Session = Depends(get_db)):
+    db_item = db.query(InventoryItem).get(item_id)
+    if not db_item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    db.delete(db_item)
+    db.commit()
+    return {"status": "deleted"}

--- a/supply_chain_system/main.py
+++ b/supply_chain_system/main.py
@@ -3,6 +3,8 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
+from .inventory.init_db import init_inventory
+
 from .inventory.routes import router as inventory_router
 from .orders.routes import router as orders_router
 from .customers.routes import router as customers_router
@@ -15,6 +17,10 @@ from .users.routes import router as users_router
 from .reports.routes import router as reports_router
 
 app = FastAPI(title="Arivu Supply Chain")
+
+@app.on_event("startup")
+def startup():
+    init_inventory()
 
 frontend_path = Path(__file__).resolve().parent.parent / "frontend"
 app.mount("/static", StaticFiles(directory=frontend_path), name="static")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,43 +3,45 @@ from fastapi.testclient import TestClient
 
 from supply_chain_system.main import app
 
-client = TestClient(app)
-
 def test_root_serves_html():
-    response = client.get("/")
-    assert response.status_code == 200
-    assert "text/html" in response.headers["content-type"]
+    with TestClient(app) as client:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
 
 
 def test_inventory_add_and_get():
-    item = {"id": 1, "name": "Flour", "quantity": 10}
-    add_resp = client.post("/inventory/", json=item)
-    assert add_resp.status_code == 200
-    get_resp = client.get("/inventory/1")
-    assert get_resp.json()["name"] == "Flour"
+    with TestClient(app) as client:
+        item = {"id": 99, "name": "TestItem", "quantity": 10}
+        add_resp = client.post("/inventory/", json=item)
+        assert add_resp.status_code == 200
+        get_resp = client.get("/inventory/99")
+        assert get_resp.json()["name"] == "TestItem"
 
 
 def test_register_and_login():
-    reg = client.post("/auth/register", params={"username": "test", "password": "pass"})
-    assert reg.status_code == 200
-    log = client.post("/auth/login", params={"username": "test", "password": "pass"})
-    assert log.status_code == 200
-    assert "token" in log.json()
+    with TestClient(app) as client:
+        reg = client.post("/auth/register", params={"username": "test", "password": "pass"})
+        assert reg.status_code == 200
+        log = client.post("/auth/login", params={"username": "test", "password": "pass"})
+        assert log.status_code == 200
+        assert "token" in log.json()
 
 
 def test_dashboards():
-    client.post("/customers", json={"id": 1, "name": "Store"})
-    client.post("/inventory", json={"id": 1, "name": "Flour", "quantity": 3})
-    client.post("/orders", json={"id": 1, "customer_id": 1, "items": [1]})
-    client.post("/invoices", json={"id": 1, "customer_id": 1, "amount": 50.0})
+    with TestClient(app) as client:
+        client.post("/customers", json={"id": 1, "name": "Store"})
+        client.post("/inventory", json={"id": 100, "name": "Widget", "quantity": 3})
+        client.post("/orders", json={"id": 1, "customer_id": 1, "items": [100]})
+        client.post("/invoices", json={"id": 1, "customer_id": 1, "amount": 50.0})
 
-    admin_resp = client.get("/dashboard/admin")
-    assert admin_resp.status_code == 200
-    data = admin_resp.json()
-    assert data["total_sales"] == 50.0
-    assert data["low_stock"][0]["product_id"] == 1
+        admin_resp = client.get("/dashboard/admin")
+        assert admin_resp.status_code == 200
+        data = admin_resp.json()
+        assert data["total_sales"] == 50.0
+        assert data["low_stock"][0]["product_id"] == 100
 
-    retailer_resp = client.get("/dashboard/retailer/1")
-    assert retailer_resp.status_code == 200
-    rdata = retailer_resp.json()
-    assert rdata["spend"] == 50.0
+        retailer_resp = client.get("/dashboard/retailer/1")
+        assert retailer_resp.status_code == 200
+        rdata = retailer_resp.json()
+        assert rdata["spend"] == 50.0


### PR DESCRIPTION
## Summary
- persist inventory items with SQLAlchemy
- preload demo inventory data on startup
- expose CRUD operations over `/inventory`
- add admin inventory page
- document preloaded data in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850036981a0832ab567d69092ba1d36