### PR TITLE
Implement user roles and update UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-__pycache__/\n*.pyc\n
+__pycache__/
+**/__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -43,16 +43,20 @@ http://localhost:8000/
   - Username: `retailer1`
   - Password: `retailpass`
 
-### 5. Features
+### 5. Registering new users
+Use `/register.html` to create additional accounts. The registration endpoint
+requires a `role` parameter with either `admin` or `retailer`.
+
+### 6. Features
 - Admin dashboard: `/dashboard.html` (auto-redirect after admin login)
 - Retailer dashboard: `/retailer_dashboard.html` (auto-redirect after retailer login)
 - Inventory, customer, and invoice management via UI
 - Download invoice PDFs and send emails (demo)
 
-### 6. Sample Data
+### 7. Sample Data
 Sample users, inventory, customers, orders, and invoices are auto-populated on first run.
 
-### 7. Notes
+### 8. Notes
 - Email notifications require a local SMTP server (for demo: `python -m smtpd -c DebuggingServer -n localhost:1025`)
 - All data is stored in `arivu.db` (SQLite)
 - All API endpoints require JWT authentication

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,12 +33,13 @@
 <script>
 document.getElementById('loginForm').addEventListener('submit', async (e) => {
     e.preventDefault();
-    const resp = await fetch('/auth/login?username=' + document.getElementById('username').value + '&password=' + document.getElementById('password').value, {method:'POST'});
+    const u = document.getElementById('username').value;
+    const p = document.getElementById('password').value;
+    const resp = await fetch('/auth/login?username=' + u + '&password=' + p, {method:'POST'});
     if (resp.ok) {
         const data = await resp.json();
         localStorage.setItem('token', data.token);
-        const user = document.getElementById('username').value;
-        if (user === 'admin') {
+        if (data.role === 'admin') {
             window.location.href = '/dashboard.html';
         } else {
             window.location.href = '/retailer_dashboard.html';

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -23,13 +23,23 @@
             <label class="form-label" for="password">Password</label>
             <input type="password" class="form-control" id="password" required>
         </div>
+        <div class="mb-3">
+            <label class="form-label" for="role">Role</label>
+            <select class="form-select" id="role">
+                <option value="retailer">Retailer</option>
+                <option value="admin">Admin</option>
+            </select>
+        </div>
         <button class="btn btn-primary w-100" type="submit">Register</button>
     </form>
 </div>
 <script>
 document.getElementById('registerForm').addEventListener('submit', async (e) => {
     e.preventDefault();
-    const resp = await fetch('/auth/register?username=' + document.getElementById('username').value + '&password=' + document.getElementById('password').value, {method:'POST'});
+    const u = document.getElementById('username').value;
+    const p = document.getElementById('password').value;
+    const role = document.getElementById('role').value;
+    const resp = await fetch('/auth/register?username=' + u + '&password=' + p + '&role=' + role, {method:'POST'});
     if (resp.ok) {
         alert('Registration successful');
         window.location.href = '/';

--- a/supply_chain_system/auth/routes.py
+++ b/supply_chain_system/auth/routes.py
@@ -6,24 +6,28 @@ router = APIRouter()
 
 class Token(BaseModel):
     token: str
+    role: str
 
 users_db: Dict[str, Dict[str, str]] = {
-    "admin": {"password": "password"}
+    "admin": {"password": "adminpass", "role": "admin"},
+    "retailer1": {"password": "retailpass", "role": "retailer"},
 }
 
 def create_token(username: str) -> str:
     return f"token-{username}"
 
 @router.post("/register")
-async def register(username: str, password: str):
+async def register(username: str, password: str, role: str):
     if username in users_db:
         raise HTTPException(status_code=400, detail="User already exists")
-    users_db[username] = {"password": password}
+    if role not in {"admin", "retailer"}:
+        raise HTTPException(status_code=400, detail="Invalid role")
+    users_db[username] = {"password": password, "role": role}
     return {"message": "registered"}
 
 @router.post("/login")
 async def login(username: str, password: str):
     user = users_db.get(username)
     if user and user["password"] == password:
-        return Token(token=create_token(username))
+        return Token(token=create_token(username), role=user["role"])
     raise HTTPException(status_code=401, detail="Invalid credentials")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,11 +32,18 @@ def test_inventory_crud():
 
 
 def test_register_and_login():
-    reg = client.post("/auth/register", params={"username": "test", "password": "pass"})
+    reg = client.post(
+        "/auth/register",
+        params={"username": "test", "password": "pass", "role": "retailer"},
+    )
     assert reg.status_code == 200
-    log = client.post("/auth/login", params={"username": "test", "password": "pass"})
+    log = client.post(
+        "/auth/login", params={"username": "test", "password": "pass"}
+    )
     assert log.status_code == 200
-    assert "token" in log.json()
+    body = log.json()
+    assert "token" in body
+    assert body["role"] == "retailer"
 
 
 def test_dashboards():


### PR DESCRIPTION
## Summary
- add role field to auth and seed admin/retailer accounts
- update login/register pages to use roles
- document registration roles in README
- adjust tests to cover roles
- ignore `__pycache__` directories

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852dd51a124832a9c9ad32fedd1fadc