### PR TITLE
Fix Pydantic date default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 **/__pycache__/
 *.pyc
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi
 uvicorn
-pydantic
+pydantic>=1.10,<2.0
 pytest
 httpx

--- a/supply_chain_system/billing/routes.py
+++ b/supply_chain_system/billing/routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 from typing import Dict
-from datetime import date
+import datetime
 
 router = APIRouter()
 
@@ -10,7 +10,7 @@ class Invoice(BaseModel):
     customer_id: int | None = None
     amount: float
     status: str = "unpaid"
-    date: date = date.today()
+    date: datetime.date = datetime.date.today()
 
 invoices: Dict[int, Invoice] = {
     1: Invoice(id=1, customer_id=1, amount=150.0, status="paid"),

--- a/supply_chain_system/production/routes.py
+++ b/supply_chain_system/production/routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Dict, List
-from datetime import date
+import datetime
 
 router = APIRouter()
 
@@ -10,12 +10,12 @@ class ProductionBatch(BaseModel):
     product: str
     status: str
     progress: int = 0
-    scheduled_start: date | None = None
+    scheduled_start: datetime.date | None = None
 
 # Sample in-memory batches
 batches: Dict[int, ProductionBatch] = {
-    1: ProductionBatch(id=1, product="Khapli Wheat Flour", status="scheduled", scheduled_start=date.today()),
-    2: ProductionBatch(id=2, product="Multi Seeds Atta", status="in_progress", progress=70, scheduled_start=date.today()),
+    1: ProductionBatch(id=1, product="Khapli Wheat Flour", status="scheduled", scheduled_start=datetime.date.today()),
+    2: ProductionBatch(id=2, product="Multi Seeds Atta", status="in_progress", progress=70, scheduled_start=datetime.date.today()),
 }
 
 alerts: List[str] = ["Low Capacity Detected"]

--- a/supply_chain_system/qc/routes.py
+++ b/supply_chain_system/qc/routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from typing import Dict, List
-from datetime import date
+import datetime
 
 router = APIRouter()
 
@@ -9,7 +9,7 @@ class QCResult(BaseModel):
     id: int
     batch_id: int
     result: str
-    date: date = date.today()
+    date: datetime.date = datetime.date.today()
 
 qc_results: Dict[int, QCResult] = {
     1: QCResult(id=1, batch_id=1, result="pass"),


### PR DESCRIPTION
## Summary
- pin pydantic to 1.x
- fix date field defaults to avoid annotation conflicts
- ignore local venv directory

## Testing
- `pytest -q`
- `uvicorn supply_chain_system.main:app --reload` (started and stopped immediately)

------
https://chatgpt.com/codex/tasks/task_e_6852ef5b1d90832a8818c9f1b0704a48