### PR TITLE
Add SQLite product catalog and dashboard updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ MRP (Maximum Retail Price): The selling price to the customer (e.g., ₹480)
 
 ## Features
 - Inventory CRUD, logs, and low stock alerts
-- Product catalog management with SKU, description, and pricing
+- Product catalog management with SKU, description, and pricing stored in `arivu.db`
 - Order management with status tracking
 - Customer management (basic CRM)
 - Billing and invoice management (PDF export)
@@ -132,11 +132,11 @@ an admin to add new users. When creating a retailer the frontend sends a special
 - Download invoice PDFs and send emails (demo)
 
 ### 7. Sample Data
-Sample users, inventory, customers, orders, and invoices are auto-populated on first run.
+Sample users, products, inventory, customers, orders, and invoices are auto-populated on first run.
 
 ### 8. Notes
 - Email notifications require a local SMTP server (for demo: `python -m smtpd -c DebuggingServer -n localhost:1025`)
-- All data is stored in `arivu.db` (SQLite)
+- All data is stored in `arivu.db` (SQLite) using SQLAlchemy models
 - All API endpoints require JWT authentication
 
 ---

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -203,7 +203,7 @@ function renderTopProducts(data) {
     new Chart(ctx, {
         type: 'bar',
         data: {
-            labels: data.map(d => d.product_id),
+            labels: data.map(d => d.name),
             datasets: [{
                 label: 'Orders',
                 data: data.map(d => d.count),
@@ -220,7 +220,7 @@ function renderLowStock(data) {
     data.forEach(i => {
         const li = document.createElement('li');
         li.className = 'list-group-item';
-        li.textContent = `${i.product_id} - ${i.quantity}`;
+        li.textContent = `${i.name || i.product_id} - ${i.quantity}`;
         list.appendChild(li);
     });
 }

--- a/frontend/retailer_dashboard.html
+++ b/frontend/retailer_dashboard.html
@@ -110,7 +110,7 @@ function renderTop(data) {
     const ctx = document.getElementById('retailerTopProducts');
     new Chart(ctx, {
         type: 'bar',
-        data: {labels:data.map(d=>d.product_id), datasets:[{data:data.map(d=>d.count), backgroundColor:'#198754'}]},
+        data: {labels:data.map(d=>d.name), datasets:[{data:data.map(d=>d.count), backgroundColor:'#198754'}]},
         options: {responsive:true,maintainAspectRatio:false,scales:{y:{beginAtZero:true}}}
     });
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pydantic>=1.10,<2.0
 pytest
 httpx
+sqlalchemy

--- a/supply_chain_system/database/__init__.py
+++ b/supply_chain_system/database/__init__.py
@@ -1,0 +1,6 @@
+"""Expose database helpers and models for easy access."""
+
+from .core import engine, SessionLocal, init_db, Base
+from .models import ProductModel
+
+__all__ = ["engine", "SessionLocal", "init_db", "Base", "ProductModel"]

--- a/supply_chain_system/database/core.py
+++ b/supply_chain_system/database/core.py
@@ -1,2 +1,18 @@
-# Placeholder database connection
-DB = {}
+"""Database initialization using SQLAlchemy and SQLite."""
+
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+
+DB_FILE = Path(__file__).resolve().parent.parent.parent / "arivu.db"
+engine = create_engine(f"sqlite:///{DB_FILE}", connect_args={"check_same_thread": False})
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def init_db():
+    """Create database tables."""
+    Base.metadata.create_all(bind=engine)
+

--- a/supply_chain_system/database/models.py
+++ b/supply_chain_system/database/models.py
@@ -1,0 +1,19 @@
+"""SQLAlchemy models for core data."""
+
+from sqlalchemy import Column, Integer, String, Float
+
+from .core import Base
+
+
+class ProductModel(Base):
+    __tablename__ = "products"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    sku = Column(String, unique=True, nullable=False)
+    description = Column(String)
+    category = Column(String)
+    uom = Column(String, nullable=False)
+    quantity_per_unit = Column(Float, nullable=False)
+    mrp = Column(Float, nullable=False)
+

--- a/supply_chain_system/products/routes.py
+++ b/supply_chain_system/products/routes.py
@@ -1,8 +1,14 @@
-from fastapi import APIRouter, HTTPException
+"""Product catalog API backed by SQLite."""
+
+from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
-from typing import Dict
+from sqlalchemy.orm import Session
+
+from ..database import SessionLocal, ProductModel
+
 
 router = APIRouter()
+
 
 class Product(BaseModel):
     id: int
@@ -14,63 +20,54 @@ class Product(BaseModel):
     quantity_per_unit: float
     mrp: float
 
-# Sample in-memory store
-products: Dict[int, Product] = {
-    1: Product(
-        id=1,
-        name="Low-Carb Multi Seeds Atta",
-        sku="AF-LCA-1KG",
-        description=(
-            "Whole Ground Flax, Sunflower, Melon, Pumpkin Seeds; Rich in Fibre, Protein, Calcium."
-        ),
-        category="Flour",
-        uom="kg",
-        quantity_per_unit=1,
-        mrp=480,
-    ),
-    2: Product(
-        id=2,
-        name="Groundnut Oil",
-        sku="AF-GNO-1L",
-        description="Cold pressed groundnut oil.",
-        category="Oil",
-        uom="L",
-        quantity_per_unit=1,
-        mrp=250,
-    ),
-}
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 @router.get("/")
-async def list_products():
-    return list(products.values())
+def list_products(db: Session = Depends(get_db)):
+    rows = db.query(ProductModel).all()
+    return [Product(**row.__dict__) for row in rows]
 
 
 @router.get("/{product_id}")
-async def get_product(product_id: int):
-    product = products.get(product_id)
-    if not product:
+def get_product(product_id: int, db: Session = Depends(get_db)):
+    prod = db.query(ProductModel).filter(ProductModel.id == product_id).first()
+    if not prod:
         raise HTTPException(status_code=404, detail="Product not found")
-    return product
+    return Product(**prod.__dict__)
 
 
 @router.post("/")
-async def add_product(product: Product):
-    products[product.id] = product
+def add_product(product: Product, db: Session = Depends(get_db)):
+    obj = ProductModel(**product.dict())
+    db.merge(obj)
+    db.commit()
     return product
 
 
 @router.put("/{product_id}")
-async def update_product(product_id: int, product: Product):
-    if product_id not in products:
+def update_product(product_id: int, product: Product, db: Session = Depends(get_db)):
+    existing = db.query(ProductModel).filter(ProductModel.id == product_id).first()
+    if not existing:
         raise HTTPException(status_code=404, detail="Product not found")
-    products[product_id] = product
+    for k, v in product.dict().items():
+        setattr(existing, k, v)
+    db.commit()
     return product
 
 
 @router.delete("/{product_id}")
-async def delete_product(product_id: int):
-    item = products.pop(product_id, None)
-    if not item:
+def delete_product(product_id: int, db: Session = Depends(get_db)):
+    obj = db.query(ProductModel).filter(ProductModel.id == product_id).first()
+    if not obj:
         raise HTTPException(status_code=404, detail="Product not found")
+    db.delete(obj)
+    db.commit()
     return {"status": "deleted"}
+


### PR DESCRIPTION
## Summary
- add SQLAlchemy and models for `Product`
- populate product catalog on startup
- expose product names in analytics APIs
- show names in dashboards for top/low-stock products
- document SQLite-backed product catalog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852f24e8984832aa6d43d90030e01b4