### PR TITLE
Add analytics service and DB models

### DIFF
--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -112,8 +112,10 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 <script>
+const token = localStorage.getItem('token');
+const authHeaders = token ? { 'Authorization': 'Bearer ' + token } : {};
 async function fetchData() {
-    const invResp = await fetch('/inventory');
+    const invResp = await fetch('/inventory', { headers: authHeaders });
     if (invResp.ok) {
         const data = await invResp.json();
         const list = document.getElementById('invList');
@@ -125,7 +127,7 @@ async function fetchData() {
             list.appendChild(li);
         });
     }
-    const custResp = await fetch('/customers');
+    const custResp = await fetch('/customers', { headers: authHeaders });
     if (custResp.ok) {
         const data = await custResp.json();
         const list = document.getElementById('custList');
@@ -137,7 +139,7 @@ async function fetchData() {
             list.appendChild(li);
         });
     }
-    const salesResp = await fetch('/dashboard/admin');
+    const salesResp = await fetch('/dashboard/admin', { headers: authHeaders });
     if (salesResp.ok) {
         const metrics = await salesResp.json();
         renderChart(metrics);
@@ -145,7 +147,7 @@ async function fetchData() {
         renderLowStock(metrics.low_stock);
     }
 
-    const prodResp = await fetch('/production');
+    const prodResp = await fetch('/production', { headers: authHeaders });
     if (prodResp.ok) {
         const data = await prodResp.json();
         const list = document.getElementById('prodList');
@@ -158,13 +160,13 @@ async function fetchData() {
         });
     }
 
-    const alertResp = await fetch('/production/alerts');
+    const alertResp = await fetch('/production/alerts', { headers: authHeaders });
     if(alertResp.ok){
         const data = await alertResp.json();
         document.getElementById('alerts').textContent = data.alerts.join(', ');
     }
 
-    const qcResp = await fetch('/qc/checks');
+    const qcResp = await fetch('/qc/checks', { headers: authHeaders });
     if(qcResp.ok){
         const data = await qcResp.json();
         const list = document.getElementById('qcList');
@@ -233,11 +235,11 @@ document.getElementById('invForm').addEventListener('submit', async e => {
         name: document.getElementById('invName').value,
         quantity: parseInt(document.getElementById('invQty').value)
     };
-    const check = await fetch('/inventory/' + item.id);
+    const check = await fetch('/inventory/' + item.id, { headers: authHeaders });
     if(check.ok){
-        await fetch('/inventory/' + item.id, {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(item)});
+        await fetch('/inventory/' + item.id, {method:'PUT', headers:{'Content-Type':'application/json', ...authHeaders}, body: JSON.stringify(item)});
     } else {
-        await fetch('/inventory', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(item)});
+        await fetch('/inventory', {method:'POST', headers:{'Content-Type':'application/json', ...authHeaders}, body: JSON.stringify(item)});
     }
     e.target.reset();
     fetchData();
@@ -248,7 +250,7 @@ document.getElementById('retForm').addEventListener('submit', async e => {
     const u = document.getElementById('retUser').value;
     const p = document.getElementById('retPass').value;
     const url = `/auth/register?username=${u}&password=${p}&role=retailer&admin_token=adminsecret`;
-    const resp = await fetch(url, {method:'POST'});
+    const resp = await fetch(url, {method:'POST', headers: authHeaders});
     if(resp.ok){
         alert('Retailer created');
         e.target.reset();

--- a/frontend/retailer_dashboard.html
+++ b/frontend/retailer_dashboard.html
@@ -71,9 +71,11 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 <script>
 const customerId = 1; // demo
+const token = localStorage.getItem('token');
+const authHeaders = token ? { 'Authorization': 'Bearer ' + token } : {};
 
 async function fetchData() {
-    const resp = await fetch('/dashboard/retailer/' + customerId);
+    const resp = await fetch('/dashboard/retailer/' + customerId, { headers: authHeaders });
     if (resp.ok) {
         const data = await resp.json();
         renderOrders(data);

--- a/supply_chain_system/analytics/routes.py
+++ b/supply_chain_system/analytics/routes.py
@@ -1,106 +1,24 @@
 from fastapi import APIRouter
 
-# import in-memory stores from other modules
-from ..billing.routes import invoices
-from ..inventory.routes import inventory
-from ..orders.routes import orders
-from ..customers.routes import customers
-from ..finished_goods.routes import finished_goods
-from datetime import date, timedelta
-from ..database import SessionLocal, ProductModel
+from ..database import SessionLocal
+from .service import get_admin_metrics, get_retailer_metrics
 
 router = APIRouter()
 
 
 @router.get("/admin")
 async def admin_dashboard():
-    """Aggregate overall KPIs for the admin dashboard."""
-    total_sales = sum(inv.amount for inv in invoices.values())
-
-    # count ordered items to determine top products
-    product_counts = {}
-    for order in orders.values():
-        for item_id in order.items:
-            product_counts[item_id] = product_counts.get(item_id, 0) + 1
-
+    """Aggregate overall KPIs for the admin dashboard from the database."""
     db = SessionLocal()
-    top_products = []
-    for pid, count in sorted(product_counts.items(), key=lambda x: x[1], reverse=True):
-        prod = db.query(ProductModel).filter(ProductModel.id == pid).first()
-        name = prod.name if prod else str(pid)
-        top_products.append({"product_id": pid, "name": name, "count": count})
+    metrics = get_admin_metrics(db)
     db.close()
-
-    low_stock = []
-    for item in inventory.values():
-        if item.quantity < 5:
-            prod = db.query(ProductModel).filter(ProductModel.id == item.id).first()
-            name = prod.name if prod else str(item.id)
-            low_stock.append({"product_id": item.id, "name": name, "quantity": item.quantity})
-
-    # compute sales for last 7 days
-    today = date.today()
-    sales_by_day = []
-    for i in range(7):
-        day = today - timedelta(days=i)
-        day_total = sum(
-            inv.amount for inv in invoices.values() if inv.date == day
-        )
-        sales_by_day.append({"date": str(day), "total": day_total})
-
-    sales_by_day.reverse()
-
-    return {
-        "total_sales": total_sales,
-        "top_products": top_products,
-        "low_stock": low_stock,
-        "customer_count": len(customers),
-        "sales_by_day": sales_by_day,
-    }
+    return metrics
 
 
 @router.get("/retailer/{customer_id}")
 async def retailer_dashboard(customer_id: int):
-    """Return KPIs for a specific retailer."""
-    cust_orders = [o for o in orders.values() if o.customer_id == customer_id]
-    cust_invoices = [i for i in invoices.values() if i.customer_id == customer_id]
-
-    product_counts = {}
-    for order in cust_orders:
-        for item_id in order.items:
-            product_counts[item_id] = product_counts.get(item_id, 0) + 1
-
+    """Return KPIs for a specific retailer from the database."""
     db = SessionLocal()
-    top_products = []
-    for pid, count in sorted(product_counts.items(), key=lambda x: x[1], reverse=True):
-        prod = db.query(ProductModel).filter(ProductModel.id == pid).first()
-        name = prod.name if prod else str(pid)
-        top_products.append({"product_id": pid, "name": name, "count": count})
+    metrics = get_retailer_metrics(db, customer_id)
     db.close()
-
-    spend = sum(inv.amount for inv in cust_invoices)
-
-    today = date.today()
-    today_sales = sum(inv.amount for inv in cust_invoices if inv.date == today)
-    trend = []
-    for i in range(7):
-        day = today - timedelta(days=i)
-        total = sum(inv.amount for inv in cust_invoices if inv.date == day)
-        trend.append({"date": str(day), "total": total})
-    trend.reverse()
-
-    fg_status = [
-        {"id": g.id, "name": g.name, "quantity": g.quantity}
-        for g in finished_goods.values()
-    ]
-    fg_low = [g for g in fg_status if g["quantity"] < 30]
-
-    return {
-        "orders": len(cust_orders),
-        "spend": spend,
-        "top_products": top_products,
-        "today_sales": today_sales,
-        "sales_trend": trend,
-        "finished_goods": fg_status,
-        "low_fg": fg_low,
-    }
+    return metrics

--- a/supply_chain_system/analytics/service.py
+++ b/supply_chain_system/analytics/service.py
@@ -1,0 +1,120 @@
+from datetime import date, timedelta
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from ..database import (
+    ProductModel,
+    RawMaterialModel,
+    ProductionBatchModel,
+    MachineModel,
+    QCCheckModel,
+    OrderModel,
+    OrderItemModel,
+    ReturnRequestModel,
+    UserModel,
+)
+
+
+def get_admin_metrics(db: Session) -> dict:
+    """Compute dashboard metrics for admin users."""
+    total_sales = db.query(func.sum(OrderModel.total_amount)).scalar() or 0
+
+    product_counts = (
+        db.query(OrderItemModel.product_id, func.count(OrderItemModel.id))
+        .group_by(OrderItemModel.product_id)
+        .all()
+    )
+    top_products = []
+    for pid, count in product_counts:
+        prod = db.query(ProductModel).filter(ProductModel.id == pid).first()
+        name = prod.name if prod else str(pid)
+        top_products.append({"product_id": pid, "name": name, "count": count})
+
+    low_stock = [
+        {
+            "product_id": rm.id,
+            "name": rm.name,
+            "quantity": rm.stock_qty,
+        }
+        for rm in db.query(RawMaterialModel)
+        .filter(RawMaterialModel.stock_qty < RawMaterialModel.reorder_point)
+        .all()
+    ]
+
+    customer_count = db.query(UserModel).filter(UserModel.role == "retailer").count()
+
+    today = date.today()
+    sales_by_day = []
+    for i in range(7):
+        day = today - timedelta(days=i)
+        day_total = (
+            db.query(func.sum(OrderModel.total_amount))
+            .filter(OrderModel.order_date == day)
+            .scalar()
+            or 0
+        )
+        sales_by_day.append({"date": str(day), "total": day_total})
+    sales_by_day.reverse()
+
+    return {
+        "total_sales": total_sales,
+        "top_products": top_products,
+        "low_stock": low_stock,
+        "customer_count": customer_count,
+        "sales_by_day": sales_by_day,
+    }
+
+
+def get_retailer_metrics(db: Session, retailer_id: int) -> dict:
+    """Metrics for a specific retailer."""
+    orders = db.query(OrderModel).filter(OrderModel.retailer_id == retailer_id).all()
+    order_ids = [o.id for o in orders]
+    invoices_total = sum(o.total_amount for o in orders)
+
+    product_counts = (
+        db.query(OrderItemModel.product_id, func.count(OrderItemModel.id))
+        .filter(OrderItemModel.order_id.in_(order_ids))
+        .group_by(OrderItemModel.product_id)
+        .all()
+    )
+    top_products = []
+    for pid, count in product_counts:
+        prod = db.query(ProductModel).filter(ProductModel.id == pid).first()
+        name = prod.name if prod else str(pid)
+        top_products.append({"product_id": pid, "name": name, "count": count})
+
+    today = date.today()
+    today_sales = (
+        db.query(func.sum(OrderModel.total_amount))
+        .filter(OrderModel.retailer_id == retailer_id, OrderModel.order_date == today)
+        .scalar()
+        or 0
+    )
+    trend = []
+    for i in range(7):
+        day = today - timedelta(days=i)
+        total = (
+            db.query(func.sum(OrderModel.total_amount))
+            .filter(OrderModel.retailer_id == retailer_id, OrderModel.order_date == day)
+            .scalar()
+            or 0
+        )
+        trend.append({"date": str(day), "total": total})
+    trend.reverse()
+
+    fg_status = [
+        {"id": b.id, "name": prod.name if (prod := db.query(ProductModel).get(b.product_id)) else str(b.product_id), "quantity": b.quantity_produced}
+        for b in db.query(ProductionBatchModel).all()
+    ]
+
+    fg_low = [g for g in fg_status if g["quantity"] < 30]
+
+    return {
+        "orders": len(orders),
+        "spend": invoices_total,
+        "top_products": top_products,
+        "today_sales": today_sales,
+        "sales_trend": trend,
+        "finished_goods": fg_status,
+        "low_fg": fg_low,
+    }

--- a/supply_chain_system/database/__init__.py
+++ b/supply_chain_system/database/__init__.py
@@ -1,6 +1,30 @@
 """Expose database helpers and models for easy access."""
 
 from .core import engine, SessionLocal, init_db, Base
-from .models import ProductModel
+from .models import (
+    ProductModel,
+    RawMaterialModel,
+    ProductionBatchModel,
+    MachineModel,
+    QCCheckModel,
+    OrderModel,
+    OrderItemModel,
+    ReturnRequestModel,
+    UserModel,
+)
 
-__all__ = ["engine", "SessionLocal", "init_db", "Base", "ProductModel"]
+__all__ = [
+    "engine",
+    "SessionLocal",
+    "init_db",
+    "Base",
+    "ProductModel",
+    "RawMaterialModel",
+    "ProductionBatchModel",
+    "MachineModel",
+    "QCCheckModel",
+    "OrderModel",
+    "OrderItemModel",
+    "ReturnRequestModel",
+    "UserModel",
+]

--- a/supply_chain_system/database/models.py
+++ b/supply_chain_system/database/models.py
@@ -1,6 +1,6 @@
 """SQLAlchemy models for core data."""
 
-from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy import Column, Integer, String, Float, Date, DateTime
 
 from .core import Base
 
@@ -16,4 +16,96 @@ class ProductModel(Base):
     uom = Column(String, nullable=False)
     quantity_per_unit = Column(Float, nullable=False)
     mrp = Column(Float, nullable=False)
+
+
+class RawMaterialModel(Base):
+    """Raw material inventory records."""
+
+    __tablename__ = "raw_materials"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    stock_qty = Column(Integer, default=0)
+    reorder_point = Column(Integer, default=0)
+    supplier_id = Column(Integer)
+
+
+class ProductionBatchModel(Base):
+    """Production batch details."""
+
+    __tablename__ = "production_batches"
+
+    id = Column(Integer, primary_key=True)
+    product_id = Column(Integer)
+    production_date = Column(Date)
+    quantity_produced = Column(Integer)
+    status = Column(String)
+
+
+class MachineModel(Base):
+    """Factory machine state."""
+
+    __tablename__ = "machines"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+
+
+class QCCheckModel(Base):
+    """Quality control results."""
+
+    __tablename__ = "qc_checks"
+
+    id = Column(Integer, primary_key=True)
+    batch_id = Column(Integer)
+    result = Column(String)
+    remarks = Column(String)
+    timestamp = Column(DateTime)
+
+
+class OrderModel(Base):
+    """Sales order header."""
+
+    __tablename__ = "orders"
+
+    id = Column(Integer, primary_key=True)
+    retailer_id = Column(Integer)
+    order_date = Column(Date)
+    total_amount = Column(Float)
+    status = Column(String)
+
+
+class OrderItemModel(Base):
+    """Line item belonging to an order."""
+
+    __tablename__ = "order_items"
+
+    id = Column(Integer, primary_key=True)
+    order_id = Column(Integer)
+    product_id = Column(Integer)
+    quantity = Column(Integer)
+    unit_price = Column(Float)
+
+
+class ReturnRequestModel(Base):
+    """Customer return requests."""
+
+    __tablename__ = "return_requests"
+
+    id = Column(Integer, primary_key=True)
+    order_id = Column(Integer)
+    reason = Column(String)
+    status = Column(String)
+
+
+class UserModel(Base):
+    """Application users."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    username = Column(String, unique=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    role = Column(String, nullable=False)
 

--- a/supply_chain_system/main.py
+++ b/supply_chain_system/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
+from datetime import date
 
 from .inventory.routes import router as inventory_router
 from .orders.routes import router as orders_router
@@ -17,7 +18,16 @@ from .products.routes import router as products_router
 from .production.routes import router as production_router
 from .qc.routes import router as qc_router
 from .finished_goods.routes import router as fg_router
-from .database import init_db, SessionLocal, ProductModel
+from .database import (
+    init_db,
+    SessionLocal,
+    ProductModel,
+    RawMaterialModel,
+    ProductionBatchModel,
+    OrderModel,
+    OrderItemModel,
+    UserModel,
+)
 
 app = FastAPI(title="Arivu Supply Chain")
 
@@ -54,6 +64,38 @@ def startup():
         ]
         db.add_all(samples)
         db.commit()
+
+        raw_materials = [
+            RawMaterialModel(id=1, name="Flax Seeds", stock_qty=100, reorder_point=20),
+            RawMaterialModel(id=2, name="Sunflower Seeds", stock_qty=50, reorder_point=20),
+        ]
+        db.add_all(raw_materials)
+
+        batches = [
+            ProductionBatchModel(id=1, product_id=1, production_date=date.today(), quantity_produced=200, status="completed"),
+            ProductionBatchModel(id=2, product_id=2, production_date=date.today(), quantity_produced=150, status="in_progress"),
+        ]
+        db.add_all(batches)
+
+        orders = [
+            OrderModel(id=1, retailer_id=1, order_date=date.today(), total_amount=500.0, status="shipped"),
+            OrderModel(id=2, retailer_id=1, order_date=date.today(), total_amount=300.0, status="pending"),
+        ]
+        db.add_all(orders)
+
+        order_items = [
+            OrderItemModel(id=1, order_id=1, product_id=1, quantity=2, unit_price=480),
+            OrderItemModel(id=2, order_id=2, product_id=2, quantity=1, unit_price=250),
+        ]
+        db.add_all(order_items)
+
+        users = [
+            UserModel(id=1, username="admin", hashed_password="admin", role="admin"),
+            UserModel(id=2, username="retailer1", hashed_password="retailer", role="retailer"),
+        ]
+        db.add_all(users)
+        db.commit()
+
     db.close()
 
 app.include_router(auth_router, prefix="/auth")


### PR DESCRIPTION
## Summary
- implement RawMaterial, ProductionBatch, Machine, QCCheck, Order, OrderItem, ReturnRequest and User models
- seed sample data for new tables during app startup
- add service layer for admin and retailer analytics
- update analytics routes to use the service
- pass JWT token in dashboard fetch calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f953f7cc832a9b0848e57f90b26f