### PR TITLE
Return user ID on login

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,6 +41,7 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
     if (resp.ok) {
         const data = await resp.json();
         localStorage.setItem('token', data.token);
+        localStorage.setItem('userId', data.id);
         if (data.role === 'admin') {
             window.location.href = '/dashboard.html';
         } else {

--- a/frontend/retailer_dashboard.html
+++ b/frontend/retailer_dashboard.html
@@ -71,7 +71,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.3/dist/chart.umd.min.js"></script>
 <script>
-const customerId = 1; // demo
+const customerId = localStorage.getItem('userId');
 
 async function fetchData() {
     const resp = await apiFetch('/dashboard/retailer/' + customerId);

--- a/supply_chain_system/auth/routes.py
+++ b/supply_chain_system/auth/routes.py
@@ -7,11 +7,12 @@ router = APIRouter()
 class Token(BaseModel):
     token: str
     role: str
+    id: int
 
 # In-memory user store with sample data
-users_db: Dict[str, Dict[str, str]] = {
-    "admin": {"password": "adminpass", "role": "admin"},
-    "retailer1": {"password": "retailpass", "role": "retailer"},
+users_db: Dict[str, Dict[str, str | int]] = {
+    "admin": {"password": "adminpass", "role": "admin", "id": 1},
+    "retailer1": {"password": "retailpass", "role": "retailer", "id": 2},
 }
 
 # Simple token that authorizes admin controlled actions (demo only)
@@ -57,5 +58,5 @@ async def login(req: LoginRequest):
     password = req.password
     user = users_db.get(username)
     if user and user["password"] == password:
-        return Token(token=create_token(username), role=user["role"])
+        return Token(token=create_token(username), role=user["role"], id=user["id"])
     raise HTTPException(status_code=401, detail="Invalid credentials")


### PR DESCRIPTION
## Summary
- include user ID in auth login response
- store ID in localStorage when logging in
- load user ID in retailer dashboard to request dynamic metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853042ad7d8832a9243c2342cc95950