### PR TITLE
Enhance admin UI and retailer workflow

### DIFF
--- a/frontend/admin_dashboard.html
+++ b/frontend/admin_dashboard.html
@@ -38,7 +38,26 @@
 </div>
 
 <div class="container py-4">
-    <div class="row text-center mb-4" id="summary">
+    <ul class="nav nav-tabs" id="adminTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="home-tab" data-bs-toggle="tab" data-bs-target="#home" type="button" role="tab">Home</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="retailers-tab" data-bs-toggle="tab" data-bs-target="#retailersPane" type="button" role="tab">Retailers</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="products-tab" data-bs-toggle="tab" data-bs-target="#productsPane" type="button" role="tab">Products</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="orders-tab" data-bs-toggle="tab" data-bs-target="#ordersPane" type="button" role="tab">Orders</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="shipments-tab" data-bs-toggle="tab" data-bs-target="#shipmentsPane" type="button" role="tab">Shipments</button>
+        </li>
+    </ul>
+    <div class="tab-content pt-3">
+        <div class="tab-pane fade show active" id="home" role="tabpanel">
+            <div class="row text-center mb-4" id="summary">
         <div class="col-md-3 mb-3 mb-md-0">
             <div class="card">
                 <div class="card-body">
@@ -152,6 +171,55 @@
             </div>
         </div>
     </div>
+        </div>
+        <div class="tab-pane fade" id="retailersPane" role="tabpanel">
+            <div class="card" id="retailers">
+                <div class="card-body">
+                    <h5 class="card-title">Retailer Accounts</h5>
+                    <ul id="retailerList" class="list-group list-group-flush"></ul>
+                    <form id="retForm" class="row g-2 mt-3">
+                        <div class="col-auto"><input class="form-control" id="retUser" placeholder="Username" required></div>
+                        <div class="col-auto"><input class="form-control" id="retPass" type="password" placeholder="Password" required></div>
+                        <div class="col-auto"><button class="btn btn-secondary" type="submit">Add Retailer</button></div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="tab-pane fade" id="productsPane" role="tabpanel">
+            <h5>Products</h5>
+            <table class="table" id="prodTable">
+                <thead>
+                <tr><th>ID</th><th>Name</th><th>SKU</th><th>Stock</th><th>Actions</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+            <form id="prodForm" class="row g-2">
+                <div class="col-auto"><input class="form-control" id="prodId" placeholder="ID" required></div>
+                <div class="col-auto"><input class="form-control" id="prodName" placeholder="Name" required></div>
+                <div class="col-auto"><input class="form-control" id="prodSku" placeholder="SKU" required></div>
+                <div class="col-auto"><input class="form-control" id="prodStock" type="number" placeholder="Stock" required></div>
+                <div class="col-auto"><button class="btn btn-primary" type="submit">Save</button></div>
+            </form>
+        </div>
+        <div class="tab-pane fade" id="ordersPane" role="tabpanel">
+            <h5>Orders</h5>
+            <table class="table" id="orderTable">
+                <thead>
+                <tr><th>ID</th><th>Retailer</th><th>Total</th><th>Status</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+        <div class="tab-pane fade" id="shipmentsPane" role="tabpanel">
+            <h5>Shipments</h5>
+            <table class="table" id="shipTable">
+                <thead>
+                <tr><th>Order</th><th>Status</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
 </div>
 
 <script src="/static/api.js"></script>
@@ -253,6 +321,9 @@ async function fetchData() {
             list.appendChild(li);
         });
     }
+
+    loadProducts();
+    loadOrders();
 }
 
 function renderChart(metrics) {
@@ -333,6 +404,46 @@ async function loadLogs(){
     });
 }
 
+async function loadProducts(){
+    const resp = await apiFetch('/products');
+    if(!resp.ok) return;
+    const data = await resp.json();
+    const tbody = document.querySelector('#prodTable tbody');
+    tbody.innerHTML = '';
+    data.forEach(p=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${p.id}</td><td>${p.name}</td><td>${p.sku}</td><td>${p.current_stock_quantity ?? 0}</td>`;
+        const del = document.createElement('button');
+        del.className = 'btn btn-danger btn-sm';
+        del.textContent = 'Delete';
+        del.onclick = async ()=>{await apiFetch('/products/'+p.id,{method:'DELETE'}); loadProducts(); fetchData();};
+        const td = document.createElement('td');
+        td.appendChild(del);
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+    });
+}
+
+async function loadOrders(){
+    const resp = await apiFetch('/orders');
+    if(!resp.ok) return;
+    const data = await resp.json();
+    const tbody = document.querySelector('#orderTable tbody');
+    const shipBody = document.querySelector('#shipTable tbody');
+    tbody.innerHTML = '';
+    shipBody.innerHTML = '';
+    data.forEach(o=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${o.id}</td><td>${o.retailer_id}</td><td>${o.total_amount}</td><td>${o.status}</td>`;
+        tbody.appendChild(tr);
+        if(o.status === 'shipped'){
+            const st = document.createElement('tr');
+            st.innerHTML = `<td>${o.id}</td><td>${o.status}</td>`;
+            shipBody.appendChild(st);
+        }
+    });
+}
+
 
 document.getElementById('invForm').addEventListener('submit', async e => {
     e.preventDefault();
@@ -369,6 +480,25 @@ document.getElementById('retForm').addEventListener('submit', async e => {
         const data = await resp.json();
         alert('Error: ' + data.detail);
     }
+});
+
+document.getElementById('prodForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const prod = {
+        id: parseInt(document.getElementById('prodId').value),
+        name: document.getElementById('prodName').value,
+        sku: document.getElementById('prodSku').value,
+        current_stock_quantity: parseInt(document.getElementById('prodStock').value)
+    };
+    const check = await apiFetch('/products/' + prod.id);
+    if(check.ok){
+        await apiFetch('/products/' + prod.id, {method:'PUT', headers:{'Content-Type':'application/json'}, body: JSON.stringify(prod)});
+    } else {
+        await apiFetch('/products', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(prod)});
+    }
+    e.target.reset();
+    loadProducts();
+    fetchData();
 });
 
 fetchData();

--- a/frontend/browse_products.html
+++ b/frontend/browse_products.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Browse Products</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<h2 class="mb-3">Browse Products</h2>
+<a href="/my_orders.html">My Orders</a>
+<table class="table" id="prodTable">
+    <thead>
+    <tr><th>ID</th><th>Name</th><th>Price</th><th>Qty</th><th></th></tr>
+    </thead>
+    <tbody></tbody>
+</table>
+<button class="btn btn-primary" id="placeOrder">Place Order</button>
+<script src="/static/api.js"></script>
+<script>
+const retailerId = localStorage.getItem('userId');
+let cart = [];
+async function load(){
+    const resp = await apiFetch('/products');
+    if(!resp.ok) return;
+    const data = await resp.json();
+    const tbody = document.querySelector('#prodTable tbody');
+    tbody.innerHTML='';
+    data.forEach(p=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${p.id}</td><td>${p.name}</td><td>${p.mrp}</td>`;
+        const qty = document.createElement('input');
+        qty.type='number';
+        qty.min=1;
+        qty.value=1;
+        const tdQty = document.createElement('td');
+        tdQty.appendChild(qty);
+        const btn = document.createElement('button');
+        btn.textContent='Add';
+        btn.className='btn btn-sm btn-secondary';
+        btn.onclick=()=>{cart.push({product_id:p.id, quantity:parseInt(qty.value), unit_price:p.mrp}); alert('Added');};
+        const tdBtn = document.createElement('td');
+        tdBtn.appendChild(btn);
+        tr.appendChild(tdQty);
+        tr.appendChild(tdBtn);
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('placeOrder').addEventListener('click', async ()=>{
+    if(!cart.length) return alert('Cart empty');
+    const id = Date.now();
+    const total = cart.reduce((s,i)=>s+i.unit_price*i.quantity,0);
+    await apiFetch('/orders', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({id, retailer_id:parseInt(retailerId), items:cart, total_amount:total})});
+    cart=[];
+    alert('Order placed');
+});
+load();
+</script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -45,7 +45,7 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
         if (data.role === 'admin') {
             window.location.href = '/admin_dashboard.html';
         } else {
-            window.location.href = '/retailer_dashboard.html';
+            window.location.href = '/browse_products.html';
         }
     } else {
         alert('Invalid credentials');

--- a/frontend/my_orders.html
+++ b/frontend/my_orders.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>My Orders</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="p-4">
+<h2 class="mb-3">My Orders</h2>
+<a href="/browse_products.html">Browse Products</a>
+<table class="table" id="orderTable">
+    <thead>
+    <tr><th>ID</th><th>Date</th><th>Total</th><th>Status</th></tr>
+    </thead>
+    <tbody></tbody>
+</table>
+<script src="/static/api.js"></script>
+<script>
+const rid = localStorage.getItem('userId');
+async function load(){
+    const resp = await apiFetch('/orders');
+    if(!resp.ok) return;
+    const data = await resp.json();
+    const tbody = document.querySelector('#orderTable tbody');
+    tbody.innerHTML='';
+    data.filter(o=>o.retailer_id==rid).forEach(o=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${o.id}</td><td>${o.order_date||''}</td><td>${o.total_amount}</td><td>${o.status}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+load();
+</script>
+</body>
+</html>

--- a/supply_chain_system/orders/routes.py
+++ b/supply_chain_system/orders/routes.py
@@ -1,32 +1,145 @@
-from fastapi import APIRouter
+from datetime import date
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from typing import List, Dict
+from sqlalchemy.orm import Session
+
+from ..database import SessionLocal, OrderModel, OrderItemModel
+
 
 router = APIRouter()
 
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+class OrderItem(BaseModel):
+    id: int
+    order_id: int
+    product_id: int
+    quantity: int
+    unit_price: float
+
+
 class Order(BaseModel):
     id: int
-    customer_id: int | None = None
-    items: List[int]
+    retailer_id: int | None = None
+    order_date: date | None = None
+    total_amount: float | None = None
     status: str = "pending"
+    items: List[OrderItem] = []
 
-orders: Dict[int, Order] = {}
 
-@router.post("/")
-async def place_order(order: Order):
-    orders[order.id] = order
-    return order
+@router.get("/")
+def list_orders(db: Session = Depends(get_db)):
+    orders = db.query(OrderModel).all()
+    results = []
+    for o in orders:
+        items = (
+            db.query(OrderItemModel)
+            .filter(OrderItemModel.order_id == o.id)
+            .all()
+        )
+        results.append(
+            Order(
+                id=o.id,
+                retailer_id=o.retailer_id,
+                order_date=o.order_date,
+                total_amount=o.total_amount,
+                status=o.status,
+                items=[
+                    OrderItem(
+                        id=i.id,
+                        order_id=i.order_id,
+                        product_id=i.product_id,
+                        quantity=i.quantity,
+                        unit_price=i.unit_price,
+                    )
+                    for i in items
+                ],
+            )
+        )
+    return results
+
 
 @router.get("/{order_id}")
-async def get_order(order_id: int):
-    return orders.get(order_id, {"error": "Order not found"})
+def get_order(order_id: int, db: Session = Depends(get_db)):
+    order = db.query(OrderModel).filter(OrderModel.id == order_id).first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    items = (
+        db.query(OrderItemModel)
+        .filter(OrderItemModel.order_id == order.id)
+        .all()
+    )
+    return Order(
+        id=order.id,
+        retailer_id=order.retailer_id,
+        order_date=order.order_date,
+        total_amount=order.total_amount,
+        status=order.status,
+        items=[
+            OrderItem(
+                id=i.id,
+                order_id=i.order_id,
+                product_id=i.product_id,
+                quantity=i.quantity,
+                unit_price=i.unit_price,
+            )
+            for i in items
+        ],
+    )
+
+
+class NewOrderItem(BaseModel):
+    product_id: int
+    quantity: int
+    unit_price: float
+
+
+class NewOrder(BaseModel):
+    id: int
+    retailer_id: int
+    order_date: date | None = None
+    items: List[NewOrderItem]
+    total_amount: float
+    status: str = "pending"
+
+
+@router.post("/")
+def create_order(order: NewOrder, db: Session = Depends(get_db)):
+    obj = OrderModel(
+        id=order.id,
+        retailer_id=order.retailer_id,
+        order_date=order.order_date or date.today(),
+        total_amount=order.total_amount,
+        status=order.status,
+    )
+    db.add(obj)
+    for item in order.items:
+        db.add(
+            OrderItemModel(
+                order_id=order.id,
+                product_id=item.product_id,
+                quantity=item.quantity,
+                unit_price=item.unit_price,
+            )
+        )
+    db.commit()
+    return {"status": "created", "id": order.id}
 
 
 @router.patch("/{order_id}/status")
-async def update_status(order_id: int, status: str):
-    order = orders.get(order_id)
+def update_status(order_id: int, status: str, db: Session = Depends(get_db)):
+    order = db.query(OrderModel).filter(OrderModel.id == order_id).first()
     if not order:
-        return {"error": "Order not found"}
+        raise HTTPException(status_code=404, detail="Order not found")
     order.status = status
-    orders[order_id] = order
-    return order
+    db.commit()
+    return {"status": status}


### PR DESCRIPTION
## Summary
- add tabbed navigation to admin dashboard with products, orders and shipments views
- implement product and order loaders and forms
- improve login redirect to new retailer pages
- extend orders API to support database-backed CRUD
- add simple browse and orders pages for retailers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853150984a8832a83c25d6179fdfd9d