### PR TITLE
Add python-jose dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ httpx
 sqlalchemy
 passlib[bcrypt]
 PyJWT
+python-jose


### PR DESCRIPTION
## Summary
- include `python-jose` in requirements to satisfy JWT usage in auth routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685321291378832abb45fc4dcc02a3da