### PR TITLE
Fix missing email-validator for FastAPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi
 uvicorn
-pydantic>=1.10,<2.0
+pydantic[email]>=1.10,<2.0
 pytest
 httpx
 sqlalchemy


### PR DESCRIPTION
## Summary
- add the `email` extra when installing pydantic to supply `email_validator`

## Testing
- `pip install -r requirements.txt`
- `uvicorn supply_chain_system.main:app --reload --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_6853221041d8832aafaa1d6f8273b3d2