### PR TITLE
Rename admin dashboard to manufacturer

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ an admin to add new users. When creating a retailer the frontend sends a special
 `admin_token` so that self-registration is blocked.
 
 ### 6. Features
- - Admin dashboard: `/admin_dashboard.html` (auto-redirect after admin login)
+ - Manufacturer dashboard: `/manufacturer_dashboard.html` (auto-redirect after admin login)
 - Retailer dashboard: `/retailer_dashboard.html` (auto-redirect after retailer login)
 - Inventory, customer, and invoice management via UI
 - Download invoice PDFs and send emails (demo)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,7 +43,7 @@ document.getElementById('loginForm').addEventListener('submit', async (e) => {
         localStorage.setItem('token', data.token);
         localStorage.setItem('userId', data.id);
         if (data.role === 'admin') {
-            window.location.href = '/admin_dashboard.html';
+            window.location.href = '/manufacturer_dashboard.html';
         } else {
             window.location.href = '/retailer_dashboard.html';
         }

--- a/frontend/manufacturer_dashboard.html
+++ b/frontend/manufacturer_dashboard.html
@@ -306,7 +306,7 @@ async function fetchData() {
             });
         });
     }
-    const salesResp = await apiFetch('/dashboard/admin');
+    const salesResp = await apiFetch('/dashboard/manufacturer');
     if (salesResp.ok) {
         const metrics = await salesResp.json();
         document.getElementById('totalSales').textContent = `₹${metrics.total_sales || 0}`;

--- a/supply_chain_system/analytics/routes.py
+++ b/supply_chain_system/analytics/routes.py
@@ -1,16 +1,16 @@
 from fastapi import APIRouter
 
 from ..database import SessionLocal
-from .service import get_admin_metrics, get_retailer_metrics
+from .service import get_manufacturer_metrics, get_retailer_metrics
 
 router = APIRouter()
 
 
-@router.get("/admin")
-async def admin_dashboard():
-    """Aggregate overall KPIs for the admin dashboard from the database."""
+@router.get("/manufacturer")
+async def manufacturer_dashboard():
+    """Aggregate overall KPIs for the manufacturer dashboard from the database."""
     db = SessionLocal()
-    metrics = get_admin_metrics(db)
+    metrics = get_manufacturer_metrics(db)
     db.close()
     return metrics
 

--- a/supply_chain_system/analytics/service.py
+++ b/supply_chain_system/analytics/service.py
@@ -15,8 +15,8 @@ from ..database import (
 )
 
 
-def get_admin_metrics(db: Session) -> dict:
-    """Compute dashboard metrics for admin users."""
+def get_manufacturer_metrics(db: Session) -> dict:
+    """Compute dashboard metrics for manufacturer (admin) users."""
     total_sales = db.query(func.sum(OrderModel.total_amount)).scalar() or 0
 
     product_counts = (


### PR DESCRIPTION
## Summary
- rename `admin_dashboard.html` to `manufacturer_dashboard.html`
- update login redirect in `index.html`
- mention new manufacturer dashboard in README
- switch analytics metrics to `/dashboard/manufacturer`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853c420c4b8832a9378b8b085c1bd22