### PR TITLE
[frontend] integrate product browsing and orders into retailer dashboard

### DIFF
--- a/frontend/retailer_dashboard.html
+++ b/frontend/retailer_dashboard.html
@@ -13,57 +13,91 @@
 </head>
 <body>
 <div class="container py-4">
-    <div class="row g-3">
-        <div class="col-12">
-            <div class="card">
-                <div class="card-body">
-                    <h5 class="card-title">Your Orders</h5>
-                    <ul id="orderList" class="list-group list-group-flush"></ul>
+    <ul class="nav nav-tabs" id="retailerTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="dash-tab" data-bs-toggle="tab" data-bs-target="#dashPane" type="button" role="tab">Dashboard</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="browse-tab" data-bs-toggle="tab" data-bs-target="#browsePane" type="button" role="tab">Browse Products</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="orders-tab" data-bs-toggle="tab" data-bs-target="#ordersPane" type="button" role="tab">My Orders</button>
+        </li>
+    </ul>
+    <div class="tab-content pt-3">
+        <div class="tab-pane fade show active" id="dashPane" role="tabpanel">
+            <div class="row g-3">
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">Your Orders</h5>
+                            <ul id="orderList" class="list-group list-group-flush"></ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">Today's Sales</h5>
+                            <div id="todaySales" class="fs-4"></div>
+                            <canvas id="salesTrend" height="120"></canvas>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">Spend</h5>
+                            <canvas id="spendChart" height="120"></canvas>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">Finished Goods</h5>
+                            <ul id="fgList" class="list-group list-group-flush"></ul>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">Order Fulfillment</h5>
+                            <div id="pending" class="mb-2"></div>
+                            <div id="shipped" class="mb-2"></div>
+                            <div id="returns"></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-md-6">
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">Top Products</h5>
+                            <canvas id="retailerTopProducts" height="120"></canvas>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="col-12 col-md-6">
-            <div class="card">
-                <div class="card-body">
-                    <h5 class="card-title">Today's Sales</h5>
-                    <div id="todaySales" class="fs-4"></div>
-                    <canvas id="salesTrend" height="120"></canvas>
-                </div>
-            </div>
+        <div class="tab-pane fade" id="browsePane" role="tabpanel">
+            <h5>Browse Products</h5>
+            <table class="table" id="prodTable">
+                <thead>
+                <tr><th>ID</th><th>Name</th><th>Price</th><th>Qty</th><th></th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+            <button class="btn btn-primary" id="placeOrder">Place Order</button>
         </div>
-        <div class="col-12 col-md-6">
-            <div class="card">
-                <div class="card-body">
-                    <h5 class="card-title">Spend</h5>
-                    <canvas id="spendChart" height="120"></canvas>
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-md-6">
-            <div class="card">
-                <div class="card-body">
-                    <h5 class="card-title">Finished Goods</h5>
-                    <ul id="fgList" class="list-group list-group-flush"></ul>
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-md-6">
-            <div class="card">
-                <div class="card-body">
-                    <h5 class="card-title">Order Fulfillment</h5>
-                    <div id="pending" class="mb-2"></div>
-                    <div id="shipped" class="mb-2"></div>
-                    <div id="returns"></div>
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-md-6">
-            <div class="card">
-                <div class="card-body">
-                    <h5 class="card-title">Top Products</h5>
-                    <canvas id="retailerTopProducts" height="120"></canvas>
-                </div>
-            </div>
+        <div class="tab-pane fade" id="ordersPane" role="tabpanel">
+            <h5>My Orders</h5>
+            <table class="table" id="orderTable">
+                <thead>
+                <tr><th>ID</th><th>Date</th><th>Total</th><th>Status</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
         </div>
     </div>
 </div>
@@ -147,7 +181,62 @@ function renderFulfillment(count){
     document.getElementById('returns').textContent = `Returns Pending: 0`;
 }
 
+let cart = [];
+
+async function loadProducts(){
+    const resp = await apiFetch('/products');
+    if(!resp.ok) return;
+    const data = await resp.json();
+    const tbody = document.querySelector('#prodTable tbody');
+    tbody.innerHTML='';
+    data.forEach(p=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${p.id}</td><td>${p.name}</td><td>${p.mrp}</td>`;
+        const qty = document.createElement('input');
+        qty.type='number';
+        qty.min=1;
+        qty.value=1;
+        const tdQty = document.createElement('td');
+        tdQty.appendChild(qty);
+        const btn = document.createElement('button');
+        btn.textContent='Add';
+        btn.className='btn btn-sm btn-secondary';
+        btn.onclick=()=>{cart.push({product_id:p.id, quantity:parseInt(qty.value), unit_price:p.mrp}); alert('Added');};
+        const tdBtn = document.createElement('td');
+        tdBtn.appendChild(btn);
+        tr.appendChild(tdQty);
+        tr.appendChild(tdBtn);
+        tbody.appendChild(tr);
+    });
+}
+
+async function loadOrders(){
+    const resp = await apiFetch('/orders');
+    if(!resp.ok) return;
+    const data = await resp.json();
+    const tbody = document.querySelector('#orderTable tbody');
+    tbody.innerHTML='';
+    data.filter(o=>o.retailer_id==customerId).forEach(o=>{
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${o.id}</td><td>${o.order_date||''}</td><td>${o.total_amount}</td><td>${o.status}</td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('placeOrder').addEventListener('click', async ()=>{
+    if(!cart.length) return alert('Cart empty');
+    const id = Date.now();
+    const total = cart.reduce((s,i)=>s+i.unit_price*i.quantity,0);
+    await apiFetch('/orders', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({id, retailer_id:parseInt(customerId), items:cart, total_amount:total})});
+    cart=[];
+    alert('Order placed');
+    loadOrders();
+    fetchData();
+});
+
 fetchData();
+loadProducts();
+loadOrders();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add navigation tabs to retailer dashboard
- merge browse_products and my_orders pages into retailer dashboard
- support placing orders from dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 supply_chain_system` *(fails: command not found)*
- `python - <<'PY'
from fastapi.testclient import TestClient
from supply_chain_system.main import app
client = TestClient(app)
for url in ['/inventory', '/dashboard/manufacturer', '/dashboard/retailer/1', '/products', '/orders']:
    resp = client.get(url)
    print(url, resp.status_code)
PY` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68558b97aaf0832a818e26203297b781